### PR TITLE
ITHD-205004: Create Major & Latest version tag on merge

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Get the next version for the readme if there are code changes to the action
         if: steps.action-code.outputs.HAS_CHANGES == 'true'
         id: version
-        uses: im-open/git-version-lite@v2.1.2
+        uses: im-open/git-version-lite@v2.2.0
         with:
           create-ref: false
           default-release-type: major
@@ -54,7 +54,7 @@ jobs:
         with:
           file-to-update: './README.md'
           action-name:  ${{ github.repository }}
-          updated-version: ${{ steps.version.outputs.NEXT_VERSION }}
+          updated-version: ${{ steps.version.outputs.NEXT_MAJOR_VERSION }}
 
       - name: Commit unstaged readme/recompile changes if there are code changes to the action
         if: steps.action-code.outputs.HAS_CHANGES == 'true'

--- a/.github/workflows/increment-version-on-merge.yml
+++ b/.github/workflows/increment-version-on-merge.yml
@@ -58,8 +58,17 @@ jobs:
       # See https://github.com/im-open/git-version-lite for more details around how to increment
       # major/minor/patch through commit messages
       - name: Increment the version
-        uses: im-open/git-version-lite@v2.1.0
+        uses: im-open/git-version-lite@v2.2.0
+        id: version
         with:
           create-ref: true
           github-token: ${{ secrets.GITHUB_TOKEN }}
           default-release-type: major
+
+      - name: Create Major Tag
+        uses: im-open/create-tags-action@v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          sha: ${{ steps.version.outputs.NEXT_VERSION_SHA }}
+          source-tag: ${{ steps.version.outputs.NEXT_VERSION }}
+          include-major: true

--- a/.github/workflows/increment-version-on-merge.yml
+++ b/.github/workflows/increment-version-on-merge.yml
@@ -72,3 +72,4 @@ jobs:
           sha: ${{ steps.version.outputs.NEXT_VERSION_SHA }}
           source-tag: ${{ steps.version.outputs.NEXT_VERSION }}
           include-major: true
+          include-latest: true

--- a/.github/workflows/increment-version-on-merge.yml
+++ b/.github/workflows/increment-version-on-merge.yml
@@ -65,7 +65,7 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           default-release-type: major
 
-      - name: Create Major Tag
+      - name: Create Major and Latest Tags
         uses: im-open/create-tags-action@v1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ jobs:
           node-version: '16'
 
       - name: Setup K6
-        uses: im-open/setup-k6-perf-testing@latest
+        uses: im-open/setup-k6-perf-testing@v1
         with:
           version: 0.38.3 # Must be >= 0.32.0
 


### PR DESCRIPTION
https://jira.extendhealth.com/servicedesk/customer/portal/26/ITHD-205004

# Summary of PR changes
Allow the creation of a major tag adjacent to the normal major + minor + patch release creation.

This allows downstream workflows to reference the major version instead of the specific minor + patch. Doing so will reduce dependabot alerts and unnecessary PRs to get the latest minor versions.

This is similar to the same pattern used with GitHub Actions.
https://github.com/actions/toolkit/blob/main/docs/action-versioning.md#recommendations

As an example, release `v1.2.3` is created with an accompanying `v1` tag.  Downstream consumers of this repo can reference `v1` instead of `v1.2.3`.

## PR Requirements
- [x] For major, minor, or breaking changes, at least one of the commit messages contains the appropriate `+semver:` keywords.
  - See the *Incrementing the Version* section of the repository's README.md for more details.
- [x] The action code does not contain sensitive information.

*NOTE: If the repo's workflow could not automatically update the `README.md`, it should be updated manually with the next version.  For javascript actions, if the repo's workflow could not automatically recompile the action it should also be updated manually as part of the PR.*