### PR TITLE
DEVO-1062 - Bump Node version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,10 +23,10 @@ jobs:
           ref: ${{ github.head_ref }}
           fetch-depth: 0
 
-      - name: Setup Node.js 20
+      - name: Setup Node.js 24
         uses: actions/setup-node@v4
         with:
-          node-version: 20.x
+          node-version: 24.x
 
       # If this step results in changes, they will be committed in the last step
       - name: Recompile and Format action

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ jobs:
         uses: actions/checkout@v4
       - uses: actions/setup-node@4
         with:
-          node-version: '20'
+          node-version: '24'
 
       - name: Setup K6
         uses: im-open/setup-k6-perf-testing@v1
@@ -76,7 +76,7 @@ jobs:
         uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '20'
+          node-version: '24'
 
       - name: Setup K6
         uses: im-open/setup-k6-perf-testing@latest


### PR DESCRIPTION
# Summary of PR changes

https://im-jira.internal.towerswatson.com/browse/DEVO-1062

This PR upgrades the Node.js version from 20 to 24 across the action's workflow and documentation.

## Changes made:
- Updated `.github/workflows/build.yml` to use Node.js 24.x instead of 20.x
- Updated README.md examples to reflect Node.js 24 in both usage examples

This is a major version change to ensure compatibility with the latest Node.js LTS version.

## PR Requirements
- [x] For major, minor, or breaking changes, at least one of the commit messages contains the appropriate `+semver:` keywords.
  - Commit message includes `+semver:major` to trigger a major version bump
  - See the *Incrementing the Version* section of the repository's README.md for more details.
- [x] The action code does not contain sensitive information.

*NOTE: If the repo's workflow could not automatically update the `README.md`, it should be updated manually with the next version. For javascript actions, if the repo's workflow could not automatically recompile the action it should also be updated manually as part of the PR.*
